### PR TITLE
Add reference to Pro Git

### DIFF
--- a/_posts/2015-09-17-Git-Introduction.md
+++ b/_posts/2015-09-17-Git-Introduction.md
@@ -297,3 +297,5 @@ Coming soon...
 
 [Intermediate Git](https://www.andyjeffries.co.uk/25-tips-for-intermediate-git-users/) - More
 complicate git commands
+
+[Pro Git](http://git-scm.com/book/en/v2) - Scott Chacon and Ben Straub's "Pro Git" book is available online for free. From very basics to git internals. Good stuff.


### PR DESCRIPTION
This adds a link to Chacon's Pro Git (I learned git from the book. I still use it as a reference.)